### PR TITLE
fix(deps): Set chai peer dependency at actual minimum version

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -36,7 +36,7 @@ updateVersion lerna
 cp README.md packages/chai-stuff
 
 git add .
-git commit -m "chore(release): bump version to $NEW_PACKAGE_VERSION"
+git commit -m "chore(release): Bump version to $NEW_PACKAGE_VERSION"
 
 npm version $1
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-stuff",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1918,12 +1918,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -2233,18 +2227,10 @@
       "dev": true
     },
     "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.0.0.tgz",
+      "integrity": "sha1-gahjrlRGmrfNAJ8JQF1guG2aGbk=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -2261,12 +2247,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chownr": {
@@ -2837,15 +2817,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3823,12 +3794,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-pkg-repo": {
@@ -6339,12 +6304,6 @@
         "pify": "^3.0.0"
       }
     },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -7615,12 +7574,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "@scottrudiger/eslint-config": "^0.7.1",
-    "chai": "^4.2.0",
+    "chai": "^1.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-import": "^2.17.3",
     "lerna": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "chai-stuff",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Chai plugin with some (maybe useful to you!) assertions.",
   "main": "index.js",
   "scripts": {

--- a/packages/chai-stuff/package.json
+++ b/packages/chai-stuff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-stuff",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Chai plugin with some (maybe useful to you!) assertions.",
   "keywords": [
     "chai-stuff",

--- a/packages/chai-stuff/package.json
+++ b/packages/chai-stuff/package.json
@@ -36,6 +36,6 @@
     "@chai-stuff/same-props": "1.0.0"
   },
   "peerDependencies": {
-    "chai": ">= 3.0.0"
+    "chai": ">= 1.0.0"
   }
 }

--- a/packages/chai-stuff/test/index.test.js
+++ b/packages/chai-stuff/test/index.test.js
@@ -12,11 +12,11 @@ describe('should be available to chai', () => {
       chai2.use(chaiStuff);
     });
     it('sameProps', () => {
-      assert.exists(chai2.assert.sameProps);
+      assert.notEqual(chai2.assert.sameProps, undefined);
     });
     it('getSamePropsAlias', () => {
       chai2.use(chaiStuff.getSamePropsAlias('someAlias'));
-      assert.exists(chai2.assert.someAlias);
+      assert.notEqual(chai2.assert.someAlias, undefined);
     });
   }); /* eslint-enable global-require */
 });

--- a/packages/same-props/package.json
+++ b/packages/same-props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chai-stuff/same-props",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Check that two objects have all the same properties (keys and values) but don't check that the objects' constructors are the same.",
   "keywords": [
     "chai-stuff",

--- a/packages/same-props/package.json
+++ b/packages/same-props/package.json
@@ -48,6 +48,6 @@
     "url": "https://github.com/chai-stuff/chai-stuff/issues"
   },
   "peerDependencies": {
-    "chai": ">= 3.0.0"
+    "chai": ">= 1.0.0"
   }
 }

--- a/packages/same-props/test/assert.test.js
+++ b/packages/same-props/test/assert.test.js
@@ -16,12 +16,12 @@ describe('assert', () => {
     it('sameProps', () => {
       const chai2 = require('chai');
       chai2.use(sameProps);
-      assert.exists(chai2.assert.sameProps);
+      assert.notEqual(chai2.assert.sameProps, undefined);
     });
     it('using getSamePropsAlias', () => {
       const chai3 = require('chai');
       chai3.use(getSamePropsAlias('someAlias'));
-      assert.exists(chai3.assert.someAlias);
+      assert.notEqual(chai3.assert.someAlias, undefined);
     });
   });
 


### PR DESCRIPTION
This plugin actually works with `chai` version `1.0.0` and higher. Therefore, this sets the packages' peer dependency requirement for `chai` to `>= 1.0.0`.