### PR TITLE
 fix(same-props): fix bug where sameProps depended on chronological ordering of keys

### DIFF
--- a/packages/same-props/lib/helpers.js
+++ b/packages/same-props/lib/helpers.js
@@ -1,0 +1,34 @@
+class ChaiStuffError extends Error {}
+
+const fillObj = nonObj => Reflect.ownKeys(nonObj).reduce((obj, key) => ({
+  ...obj,
+  [key]: nonObj[key],
+}), {});
+
+const getOwnSortedPropertyNames = obj => Object.getOwnPropertyNames(obj).sort();
+
+const strictEqual = (actual, expected) => {
+  if (actual !== expected)
+    throw new ChaiStuffError(`expected ${actual} to equal ${expected}`);
+};
+
+const types = new Map([
+  [Map, map => [...map].reduce((obj, [key, val]) => ({
+    ...obj,
+    [key]: val,
+  }), {})],
+  [Set, set => [...set]],
+  [WeakMap, () => { throw new ChaiStuffError('WeakMaps cannot be compared'); }],
+  [WeakSet, () => { throw new ChaiStuffError('WeakSets cannot be compared'); }],
+  [Number, num => ({Number: +num, ...num})],
+  [String, str => fillObj(str)],
+  [Boolean, bool => ({Boolean: bool.valueOf(), ...bool})],
+]);
+
+export {
+  ChaiStuffError,
+  fillObj,
+  getOwnSortedPropertyNames,
+  strictEqual,
+  types,
+};

--- a/packages/same-props/lib/index.js
+++ b/packages/same-props/lib/index.js
@@ -1,27 +1,10 @@
-class ChaiStuffError extends Error {}
-
-const fillObj = nonObj => Reflect.ownKeys(nonObj).reduce((obj, key) => ({
-  ...obj,
-  [key]: nonObj[key],
-}), {});
-
-const types = new Map([
-  [Map, map => [...map].reduce((obj, [key, val]) => ({
-    ...obj,
-    [key]: val,
-  }), {})],
-  [Set, set => [...set]],
-  [WeakMap, () => { throw new ChaiStuffError('WeakMaps cannot be compared'); }],
-  [WeakSet, () => { throw new ChaiStuffError('WeakSets cannot be compared'); }],
-  [Number, num => ({Number: +num, ...num})],
-  [String, str => fillObj(str)],
-  [Boolean, bool => ({Boolean: bool.valueOf(), ...bool})],
-]);
-
-const strictEqual = (actual, expected) => {
-  if (actual !== expected)
-    throw new ChaiStuffError(`expected ${actual} to equal ${expected}`);
-};
+import {
+  ChaiStuffError,
+  fillObj,
+  getOwnSortedPropertyNames,
+  strictEqual,
+  types,
+} from './helpers';
 
 const getSameProps = (alias = 'sameProps') => ({assert}, {addMethod, inspect}) => (
   addMethod(assert, alias, (actual, expected, message) => {
@@ -46,8 +29,8 @@ const getSameProps = (alias = 'sameProps') => ({assert}, {addMethod, inspect}) =
         _expected.converted = types.get(expected.constructor)(expected);
       else if (expected[Symbol.iterator])
         _expected.converted = [...expected];
-      const actualKeys = Object.getOwnPropertyNames(_actual.converted);
-      assert.deepEqual(actualKeys, Object.getOwnPropertyNames(_expected.converted));
+      const actualKeys = getOwnSortedPropertyNames(_actual.converted);
+      assert.deepEqual(actualKeys, getOwnSortedPropertyNames(_expected.converted));
       assert.isTrue(
         actualKeys.every(key => _actual.converted[key] === _expected.converted[key]),
       );

--- a/packages/same-props/test/assert.test.js
+++ b/packages/same-props/test/assert.test.js
@@ -170,6 +170,20 @@ describe('assert', () => {
     }); /* eslint-enable no-new-wrappers */
   });
 
+  it('should not depend on order of props', () => {
+    assert.sameProps(
+      {c: null, b: null, a: null, 3: null, 2: null, 1: null},
+      {a: null, b: null, c: null, 1: null, 2: null, 3: null},
+    );
+  });
+
+  it('should not pass just because objects have the same number of props', () => {
+    assert.throw(() => assert.sameProps(
+      {a: undefined, b: undefined, c: undefined},
+      {d: undefined, e: undefined, f: undefined},
+    ));
+  });
+
   context('should not work w/ objects:', () => {
     it('WeakMaps', () => {
       assert.throws(() => assert.sameProps(new WeakMap([[{}, 1]]), new WeakMap([[{}, 1]])));


### PR DESCRIPTION
The ordering of `String` keys in two objects incorrectly determined whether or not `sameProps` passed or failed.

For example:

```js
assert.throws(() => assert.sameProps(
  {a: '', b: '', c: '', 1: '', 2: '', 3: ''},
  {3: '', 2: '', 1: '', c: '', b: '', a: ''},
));
```

Prior to this change, `sameProps` would fail because of the ordering of `Object.getOwnPropertyNames`:

1. Insert sorted integer keys.
2. Insert non-integer string keys in chronological order.

In essence:

```js
assert.throws(() => assert.deepEqual(
  [1, 2, 3, 'a', 'b', 'c'],
  [1, 2, 3, 'c', 'b', 'a'],
));
```

However, starting with version `0.3.1` `sameProps` will ignore the original ordering of keys for comparison; i.e.:

```js
assert.sameProps(
  {a: '', b: '', c: '', 1: '', 2: '', 3: ''},
  {3: '', 2: '', 1: '', c: '', b: '', a: ''},
);

// inner comparison
assert.deepEqual(
  [1, 2, 3, 'a', 'b', 'c'],
  [1, 2, 3, 'a', 'b', 'c'],
);
```