### PR TITLE
fix(compatibility): remove 'Reflect.ownKeys' for usage with node v4

### DIFF
--- a/packages/same-props/lib/helpers.js
+++ b/packages/same-props/lib/helpers.js
@@ -1,9 +1,9 @@
 class ChaiStuffError extends Error {}
 
-const fillObj = nonObj => Reflect.ownKeys(nonObj).reduce((obj, key) => ({
-  ...obj,
-  [key]: nonObj[key],
-}), {});
+const fillObj = nonObj => [
+  ...Object.getOwnPropertyNames(nonObj),
+  ...Object.getOwnPropertySymbols(nonObj),
+].reduce((obj, key) => ({...obj, [key]: nonObj[key]}), {});
 
 const getOwnSortedPropertyNames = obj => Object.getOwnPropertyNames(obj).sort();
 


### PR DESCRIPTION
This change allows `chai-stuff` to be used in Node.js `v4`. Beforehand, Node.js must have been at at least `v6` in order to make use of `Reflect.ownKeys`.