### PR TITLE
build(chai-stuff): reduce package size by excluding unnecessary code from bundle

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-stuff",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "chai-stuff",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Chai plugin with some (maybe useful to you!) assertions.",
   "main": "index.js",
   "scripts": {

--- a/packages/chai-stuff/lib/index.js
+++ b/packages/chai-stuff/lib/index.js
@@ -1,5 +1,5 @@
-import {notLengthOf, getNotLengthOfAlias} from '../../not-length-of/lib/index';
-import {sameProps, getSamePropsAlias} from '../../same-props/lib/index';
+const {notLengthOf, getNotLengthOfAlias} = require('@chai-stuff/not-length-of');
+const {sameProps, getSamePropsAlias} = require('@chai-stuff/same-props');
 
 const chaiStuff = (chai, utils) => {
   notLengthOf(chai, utils);

--- a/packages/chai-stuff/package.json
+++ b/packages/chai-stuff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-stuff",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Chai plugin with some (maybe useful to you!) assertions.",
   "keywords": [
     "chai-stuff",
@@ -39,7 +39,7 @@
     "chai": ">= 1.0.0"
   },
   "dependencies": {
-    "@chai-stuff/not-length-of": "0.3.1",
-    "@chai-stuff/same-props": "0.3.1"
+    "@chai-stuff/not-length-of": "0.3.2",
+    "@chai-stuff/same-props": "0.3.2"
   }
 }

--- a/packages/not-length-of/package.json
+++ b/packages/not-length-of/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chai-stuff/not-length-of",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Check that an object does not have a length or size property with the expected value.",
   "main": "dist/index.js",
   "files": [

--- a/packages/same-props/package.json
+++ b/packages/same-props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chai-stuff/same-props",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Check that two objects have all the same properties (keys and values) but don't check that the objects' constructors are the same.",
   "keywords": [
     "chai-stuff",


### PR DESCRIPTION
Prior to this change, `rollup` was configured to bundle assertion code into `packages/chai-stuff/dist/index.js`. Each `@chai-stuff/*` assertion was also a dependency of `chai-stuff`. This caused duplicate code when installing the package.

As of `v0.3.2`, assertion code will no longer be bundled into `chai-stuff`. Instead, it will `require` each `@chai-stuff/*` package and use the code exported therefrom.